### PR TITLE
[Fix] sign_upとsign_inのルーティングエラー解消

### DIFF
--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -1,27 +1,4 @@
 # frozen_string_literal: true
 
 class Public::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
-
-  # GET /resource/sign_in
-  # def new
-  #   super
-  # end
-
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
-
-  # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
-
-  # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_in_params
-  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
-  # end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,13 @@ get '/admin' => 'admin/homes#top', as: 'admin'
 get "about" => "public/homes#about", as: "about"
 
 
+# 顧客用
+# URL /customers/sign_in ...
+devise_for :customers,skip: [:passwords], controllers: {
+  registrations: "public/registrations",
+  sessions: 'public/sessions'
+}
+
 scope module: 'public' do
   resources :items, only: [:index, :show]
   resources :customers, only: [:show, :edit, :update, :destroy]
@@ -17,12 +24,7 @@ end
 get "customers/:id/exit" => "public/customers#exit", as: "customer_exit"
 
 
-# 顧客用
-# URL /customers/sign_in ...
-devise_for :customers,skip: [:passwords], controllers: {
-  registrations: "public/registrations",
-  sessions: 'public/sessions'
-}
+
 
 
 # 管理者用


### PR DESCRIPTION
deviceのルーティング（devise_for :customers...）を「scope module: 'public' do」の上に移動